### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Node implementation of a T1 API Library. Uses [Bluebird](http://bluebirdjs.com/d
 
 ### Compilation/Installation
 #### From npm
-` npm install terminalone `
+` npm install @mediamath/terminalone `
 #### From source
 Checkout, then `npm install .`
 
@@ -56,9 +56,12 @@ Retrieve, edit and save a single entity
 ``` js
 var agencyPromise = new t1.Entity('agency')
   .get(1234, connection)
-  .then(function(agency) {this.agency = agency});
-agency.name = 'new name';
-agency.save(connection).done(console.log('saved'));
+  .then(function(agency) {
+    this.agency = agency;
+    agency.name = 'new name';
+    agency.save(connection).then(function () {
+      console.log('saved')})
+    });
 ```
 
 ##### Entity Lists
@@ -69,10 +72,12 @@ Returns a generator to entities
 var userParams = {
   'page_limit':10
   };
-t1.EntityList.get('campaigns', connection,  userParams).then(function(list) {this.pg1 = list});
-t1.EntityList.getNextPage(pg1, connection).then(function(list) {this.pg2 = list});
-
-for (var entity of pg1.entities) {console.log(entity)}
+t1.EntityList.get('campaigns', connection,  userParams).then(function(list) {
+  this.pg1 = list;
+  t1.EntityList.getNextPage(pg1, connection).then(function(list) {
+    this.pg2 = list });
+  for (var entity of this.pg1.entities) {console.log(entity)}
+  });
 ```
 
 
@@ -84,10 +89,9 @@ var userParams = {
   'page_limit':10
   'with':['strategies']
   };
-t1.EntityList.get('campaigns', connection,  userParams).then(function(list) {this.pg1 = list});
-t1.EntityList.getNextPage(pg1, connection).then(function(list) {this.pg2 = list});
-
-for (var entity of pg1.entities) {console.log(entity)}
+t1.EntityList.get('campaigns', connection,  userParams).then(function(list) {
+  this.pg1 = list;
+  for (var entity of list.entities) {console.log(entity)}});
 ```
 
 #### Targeting
@@ -106,7 +110,7 @@ targetingSegments.include = [[1, 'OR']];
 targetingSegments.exclude = [[119, 'OR']];
 targetingSegments.include_op = 'OR';
 targetingSegments.exclude_op = 'OR';
-targetingSegments.save(connection).done(console.log('saved'));
+targetingSegments.save(connection).then(function () { console.log('saved') });
 ```
 
 ##### Strategy Target Dimensions/Values
@@ -121,7 +125,7 @@ To edit strategy targeting segments:
 ``` js
 targetValues.include = [[1, 'OR']];
 targetValues.addTargetValues('REGN', 'INCLUDE', 'OR', [23, 251]);
-targetValues.save(connection).done(console.log('saved'));
+targetValues.save(connection).then(function () { console.log('saved') });
 ```
 
 ##### Strategy Audience Segments
@@ -138,7 +142,7 @@ audienceSegments.include = [1405158];
 audienceSegments.exclude = [1405158];
 targetingSegments.include_op = 'OR';
 targetingSegments.exclude_op = 'OR';
-targetingSegments.save(connection).done(console.log('saved'));
+targetingSegments.save(connection).then(function () { console.log('saved') });
 ```
 
 #### Basic Reporting

--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ Retrieve, edit and save a single entity
 var agencyPromise = new t1.Entity('agency')
   .get(1234, connection)
   .then(function(agency) {
-    this.agency = agency;
+    agency = agency;
     agency.name = 'new name';
-    agency.save(connection).then(function () {
+    return agency.save(connection)
+    })
+    .then(function () {
       console.log('saved')})
-    });
+    .catch(error => console.log(error));
 ```
 
 ##### Entity Lists
@@ -72,12 +74,15 @@ Returns a generator to entities
 var userParams = {
   'page_limit':10
   };
-t1.EntityList.get('campaigns', connection,  userParams).then(function(list) {
-  this.pg1 = list;
-  t1.EntityList.getNextPage(pg1, connection).then(function(list) {
-    this.pg2 = list });
-  for (var entity of this.pg1.entities) {console.log(entity)}
-  });
+t1.EntityList.get('campaigns', connection,  userParams)
+.then(function(list) {
+  pg1 = list;
+  return t1.EntityList.getNextPage(pg1, connection)
+  })
+    .then(function(list) {
+    pg2 = list;
+    for (var entity of list.entities) {console.log(entity)}});
+  
 ```
 
 
@@ -86,11 +91,11 @@ It's possible to include related entities by including in a 'with' property in u
 
 ``` js
 var userParams = {
-  'page_limit':10
+  'page_limit':10,
   'with':['strategies']
   };
 t1.EntityList.get('campaigns', connection,  userParams).then(function(list) {
-  this.pg1 = list;
+  pg1 = list;
   for (var entity of list.entities) {console.log(entity)}});
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,13 +74,14 @@ Returns a generator to entities
 var userParams = {
   'page_limit':10
   };
+var that = this;
 t1.EntityList.get('campaigns', connection,  userParams)
 .then(function(list) {
-  pg1 = list;
+  that.pg1 = list;
   return t1.EntityList.getNextPage(pg1, connection)
   })
     .then(function(list) {
-    pg2 = list;
+    that.pg2 = list;
     for (var entity of list.entities) {console.log(entity)}});
   
 ```
@@ -94,8 +95,9 @@ var userParams = {
   'page_limit':10,
   'with':['strategies']
   };
+var that = this;
 t1.EntityList.get('campaigns', connection,  userParams).then(function(list) {
-  pg1 = list;
+  that.pg1 = list;
   for (var entity of list.entities) {console.log(entity)}});
 ```
 


### PR DESCRIPTION
fix module name in npm install command
examples were causing some confusion since they were not copy-pastable. 